### PR TITLE
[Refactor] Use Arn to reference Lambda in SQS event source

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -242,7 +242,9 @@ describe('generateResources method', () => {
           EventSourceArn: {
            'Fn::GetAtt': ['SQSQueuebarqueue', 'Arn'],
           },
-          FunctionName: {Ref: 'barLogicalID'}
+          FunctionName: {
+            'Fn::GetAtt': ['barLogicalID', 'Arn']
+          }
         },
       },
       foohappenedTobaz: {

--- a/src/index.js
+++ b/src/index.js
@@ -401,7 +401,10 @@ class ServerlessPluginPubSub {
         ]
       },
       FunctionName: {
-        Ref: this.naming.getLambdaLogicalId(sub.subscriber.name)
+        'Fn::GetAtt': [
+          this.naming.getLambdaLogicalId(sub.subscriber.name),
+          'Arn'
+        ]
       },
     };
     this.slsCustomResources[logicalId] = {


### PR DESCRIPTION
Cloudformation accepts either the function name or the Arn. This changes it to use the Arn to match the default serverless behavior.